### PR TITLE
fix(feed): sanitize multiline previews to prevent overlay layout corruption

### DIFF
--- a/overlay.ts
+++ b/overlay.ts
@@ -3,7 +3,7 @@
  */
 
 import type { Component, Focusable, TUI } from "@mariozechner/pi-tui";
-import { matchesKey, visibleWidth } from "@mariozechner/pi-tui";
+import { matchesKey, truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
 import type { Theme } from "@mariozechner/pi-coding-agent";
 import {
   extractFolder,
@@ -553,7 +553,14 @@ export class MessengerOverlay implements Component, Focusable {
     const sectionW = innerW - 2;
     const border = (s: string) => this.theme.fg("dim", s);
     const pad = (s: string, len: number) => s + " ".repeat(Math.max(0, len - visibleWidth(s)));
-    const row = (content: string) => border("│") + pad(" " + content, innerW) + border("│");
+    const sanitizeRowContent = (content: string) => content
+      .replaceAll("\r", " ")
+      .replaceAll("\n", " ")
+      .replaceAll("\t", " ");
+    const row = (content: string) => {
+      const safe = truncateToWidth(sanitizeRowContent(content), sectionW);
+      return border("│") + pad(" " + safe, innerW) + border("│");
+    };
     const emptyRow = () => border("│") + " ".repeat(innerW) + border("│");
     const sectionSeparator = this.theme.fg("dim", "─".repeat(sectionW));
 

--- a/tests/crew/live-feed.test.ts
+++ b/tests/crew/live-feed.test.ts
@@ -92,6 +92,22 @@ describe("renderFeedSection (pure formatter)", () => {
     expect(joined).toContain("refreshTokenRotation");
   });
 
+  it("sanitizes embedded newlines in message previews", () => {
+    const events: FeedEvent[] = [{
+      ts: "2026-01-01T00:01:00Z",
+      agent: "EpicGrove",
+      type: "message",
+      target: "OakBear",
+      preview: "Step one\nStep two\nStep three",
+    }];
+    const lines = renderFeedSection(mockTheme as any, events, 50, null);
+    const joined = lines.join(" ");
+    expect(joined).toContain("Step one Step two Step three");
+    for (const line of lines) {
+      expect(line).not.toContain("\n");
+    }
+  });
+
   it("renders broadcast message events with ✦ indicator", () => {
     const events: FeedEvent[] = [{
       ts: "2026-01-01T00:01:00Z",

--- a/tests/feed.test.ts
+++ b/tests/feed.test.ts
@@ -112,6 +112,23 @@ describe("feed", () => {
     expect(line.length).toBeLessThan(200);
   });
 
+  it("normalizes multiline preview text into a single line", () => {
+    logFeedEvent(cwd, "AgentOne", "message", "Peer", "Line one\nLine two\tLine three");
+
+    const events = readFeedEvents(cwd, 20);
+    expect(events).toHaveLength(1);
+    expect(events[0]?.preview).toBe("Line one Line two Line three");
+
+    const line = formatFeedLine({
+      ts: new Date("2026-02-13T10:00:00.000Z").toISOString(),
+      agent: "AgentOne",
+      type: "commit",
+      preview: "feat(scope): add thing\n\nBody details",
+    });
+    expect(line).toContain("feat(scope): add thing Body details");
+    expect(line).not.toContain("\n");
+  });
+
   it("returns an empty array when the feed file does not exist", () => {
     const freshCwd = createTempCrewDirs().cwd;
     expect(readFeedEvents(freshCwd, 20)).toEqual([]);


### PR DESCRIPTION
## Summary

| Before | After |
| ------ | ------ |
|  <img width="1582" height="1034" alt="Screenshot 2026-02-23 at 19 03 25" src="https://github.com/user-attachments/assets/eecccc6b-397c-4d79-8e26-af6b152c91c6" /> | <img width="1582" height="1034" alt="Screenshot 2026-02-23 at 19 02 59" src="https://github.com/user-attachments/assets/faebeeea-0e2c-41f7-9c01-65d6cd73c5a0" />  |


Fixes overlay layout corruption caused by multiline data in `.pi/messenger/feed.jsonl`.

The root cause was feed events with embedded newlines (for example, commit/message previews). Those newline characters were rendered into the TUI row pipeline and broke panel borders/section alignment.

## What changed

- **`feed.ts`**
  - Added feed event sanitization for inline text fields (`agent`, `target`, `preview`)
  - Applied sanitization when appending events, reading events, and formatting feed lines
- **`overlay-render.ts`**
  - Sanitizes feed events before rendering message and non-message lines
- **`overlay.ts`**
  - Hardened row rendering by stripping control whitespace (`\n`, `\r`, `\t`) and truncating to section width before drawing borders
- **Tests**
  - Added regression coverage for multiline preview normalization and rendering safety:
    - `tests/feed.test.ts`
    - `tests/crew/live-feed.test.ts`

## Validation

- `npm test` passes (full suite)
- Reproduced problematic `.pi` data now renders cleanly without layout breakage
