### PR TITLE
fix(crew): respect crew.models config override for agent models

### DIFF
--- a/crew/agents.ts
+++ b/crew/agents.ts
@@ -203,7 +203,7 @@ async function runAgent(
   return new Promise((resolve) => {
     // Build args for pi command
     const args = ["--mode", "json", "--no-session", "-p"];
-    const model = task.modelOverride ?? agentConfig?.model;
+    const model = task.modelOverride ?? config.models?.[role] ?? agentConfig?.model;
     if (model) pushModelArgs(args, model);
 
     const thinking = resolveThinking(

--- a/overlay-render.ts
+++ b/overlay-render.ts
@@ -341,7 +341,8 @@ export function renderEmptyState(theme: Theme, cwd: string, width: number, heigh
     lines.push(theme.fg("dim", "  (none discovered)"));
   } else {
     for (const agent of agents) {
-      const model = agent.model ? ` (model: ${agent.model})` : "";
+      const effectiveModel = crewConfig.models?.[agent.crewRole ?? "worker"] ?? agent.model;
+      const model = effectiveModel ? ` (model: ${effectiveModel})` : "";
       lines.push(`  ${agent.name}${model}`);
     }
   }

--- a/tests/crew/model-override.test.ts
+++ b/tests/crew/model-override.test.ts
@@ -51,6 +51,12 @@ You are a test worker.
   fs.writeFileSync(filePath, content);
 }
 
+function writeCrewConfig(cwd: string, models: Record<string, string | null>): void {
+  const configPath = path.join(cwd, ".pi", "messenger", "crew", "config.json");
+  fs.mkdirSync(path.dirname(configPath), { recursive: true });
+  fs.writeFileSync(configPath, JSON.stringify({ models }));
+}
+
 describe("crew/model override", () => {
   let dirs: TempCrewDirs;
 
@@ -91,6 +97,7 @@ describe("crew/model override", () => {
 
   it("spawnAgents falls back to agent model when no override is provided", async () => {
     writeWorkerAgent(dirs.cwd, "agent-default-model");
+    writeCrewConfig(dirs.cwd, { worker: null });
 
     await spawnAgents([{
       agent: "crew-worker",
@@ -107,6 +114,7 @@ describe("crew/model override", () => {
 
   it("spawnAgents splits provider/model into --provider and --model flags", async () => {
     writeWorkerAgent(dirs.cwd, "zai/glm-5");
+    writeCrewConfig(dirs.cwd, { worker: null });
 
     await spawnAgents([{
       agent: "crew-worker",


### PR DESCRIPTION
## Problem

The "crew.models" configuration from user config (`~/.pi/agent/pi-messenger.json`) was being loaded by `loadCrewConfig` but was not actually being applied when spawning crew agents. The TUI also displayed the hardcoded agent models from the agent definition files instead of the effective models that would be used.

## Changes

- **`crew/agents.ts`**: Added `config.models?.[role]` to the model resolution chain in `spawnAgents`, so the priority is now:
  1. Task-level override (`task.modelOverride`)
  2. Config override (`config.models?.[role]`) ← **NEW**
  3. Agent default (`agentConfig?.model`)

- **`overlay-render.ts`**: Updated `renderEmptyState` to display the effective model (config override + agent default) instead of just the hardcoded agent model.

- **`tests/crew/model-override.test.ts`**: Added `writeCrewConfig` helper and updated tests to isolate from the user's actual config.

## Example

With this user config:
```json
{
  "crew": {
    "models": {
      "worker": "kimi-coding/k2p5",
      "planner": "kimi-coding/k2p5",
      "reviewer": "kimi-coding/k2p5",
      "analyst": "kimi-coding/k2p5"
    }
  }
}
```

<img width="1582" height="1034" alt="image" src="https://github.com/user-attachments/assets/35992997-b53a-4bdf-a41b-fca4466a38c7" />

All crew agents will now use `kimi-coding/k2p5` instead of the hardcoded Anthropic models.

## Testing

- All 287 tests pass
- Model resolution follows correct priority order
- TUI displays effective models correctly