### PR TITLE
fix: prevent workers from loading orchestrator-only skills (token burn)

### DIFF
--- a/crew/agents/crew-worker.md
+++ b/crew/agents/crew-worker.md
@@ -37,7 +37,9 @@ read({ path: ".pi/messenger/crew/tasks/<TASK_ID>.md" })
 
 ## Phase 2.5: Load Relevant Skills
 
-If your task prompt includes an **Available Skills** section, read any that match what you're building before starting implementation.
+If your task prompt includes an **Available Skills** section, read skills that match what you're **building** (e.g. a framework, testing library, or domain-specific tool).
+
+**Do NOT read `pi-messenger-crew`** — you already have every `pi_messenger` action you need in this prompt.
 
 If skills are marked **Recommended for this task**, read those first.
 
@@ -45,7 +47,7 @@ If skills are marked **Recommended for this task**, read those first.
 read({ path: "<skill-path-from-the-list>" })
 ```
 
-Skip this phase if no Available Skills section is present.
+Skip this phase if no Available Skills section is present or no skills match your implementation work.
 
 ## Phase 3: Start Task & Reserve Files
 

--- a/skills/pi-messenger-crew/SKILL.md
+++ b/skills/pi-messenger-crew/SKILL.md
@@ -1,9 +1,15 @@
 ---
 name: pi-messenger-crew
-description: Use pi-messenger for multi-agent coordination and Crew task orchestration. Covers joining the mesh, planning from PRDs, working on tasks, file reservations, and agent messaging. Load this skill when using pi_messenger or building with Crew.
+description: Orchestrator reference for pi-messenger Crew — planning, task management, config, and agent coordination. Workers already have everything they need in crew-worker.md and should NOT load this skill.
 ---
 
 # Pi-Messenger Crew Skill
+
+> **Workers:** You do not need this skill. Your `crew-worker.md` prompt already contains every `pi_messenger` action you need (`join`, `task.start/done/progress/block`, `reserve`, `release`, `send`). Loading this adds ~2,000 tokens of orchestrator docs that are irrelevant to your task.
+>
+> **Orchestrators / humans:** This is your full reference for planning, task management, configuration, and understanding crew internals.
+
+---
 
 Use pi-messenger for multi-agent coordination and Crew task orchestration.
 


### PR DESCRIPTION
# PR Title
fix: prevent workers from loading orchestrator-only skills (token burn + coordination)

---

# Problem

During crew execution, workers were burning a significant number of tokens loading skills that were never relevant to them.

## Root Cause 1 — `pi-messenger-crew` skill loaded by every worker

The `pi-messenger-crew` skill (~2,000 tokens) is discovered by the crew skill scanner and listed as "Available" in every worker's prompt. Workers read it because its description says:

> "Load this skill when using pi_messenger or building with Crew."

Workers DO use `pi_messenger`, so they load it. But `crew-worker.md` already contains every `pi_messenger` action a worker ever needs (`join`, `task.start/done/progress/block`, `reserve`, `release`, `send`). The skill's remaining ~1,800 tokens cover planning, config tables, model override priority, graceful shutdown internals, data storage paths, keybindings — all orchestrator concerns, invisible to workers.

**Impact**: In a typical run with 2 concurrent workers and 10 waves, this skill alone adds ~40,000 unnecessary tokens. With Sonnet-class models at worker level, this is material cost.

## Root Cause 2 — `dependencies: "advisory"` enables same-task double-assignment

With the default `advisory` dependency mode and `minimal` or no coordination, two workers can race onto the same task:
- Worker A completes task-1 and looks for next available work
- Worker B also completes task-1 (parallel) and scans for next task
- Both see task-2 (depends on task-1, which is now done) as ready
- Both call `task.start` in a narrow race window

This is documented as a user-reported issue — "same task assigned to multiple agents." While `task.start` has server-side atomicity for the record, the race is visible in the coordination layer before the call is made (workers pre-select a task to claim, then start it). The fix at the config level is `dependencies: "strict"`, but the default should be documented more prominently.

---

# Changes

## 1. `skills/pi-messenger-crew/SKILL.md`

**Frontmatter description** updated to make the audience explicit:

```
Before:
  "Use pi-messenger for multi-agent coordination and Crew task orchestration.
   Covers joining the mesh, planning from PRDs, working on tasks, file reservations,
   and agent messaging. Load this skill when using pi_messenger or building with Crew."

After:
  "Orchestrator reference for pi-messenger Crew — planning, task management, config,
   and agent coordination. Workers already have everything they need in crew-worker.md
   and should NOT load this skill."
```

**Body** — added a prominent callout block immediately below the heading:

```markdown
> **Workers:** You do not need this skill. Your `crew-worker.md` prompt already contains
> every `pi_messenger` action you need (`join`, `task.start/done/progress/block`,
> `reserve`, `release`, `send`). Loading this adds ~2,000 tokens of orchestrator docs
> that are irrelevant to your task.
>
> **Orchestrators / humans:** This is your full reference for planning, task management,
> configuration, and understanding crew internals.
```

All existing content is preserved unchanged after the callout.

## 2. `crew/agents/crew-worker.md`

Phase 2.5 (Load Relevant Skills) updated with an explicit skip note:

```markdown
Before:
  "If your task prompt includes an Available Skills section, read any that match
   what you're building before starting implementation."

After:
  "If your task prompt includes an Available Skills section, read skills that match
   what you're building (e.g. a framework, testing library, or domain-specific tool).

   Do NOT read `pi-messenger-crew` — you already have every pi_messenger action
   you need in this prompt."
```

---

# Why Not Split the Skill File?

An alternative approach would be to split `pi-messenger-crew` into separate `pi-messenger-worker` and `pi-messenger-orchestrator` skills. This was considered and rejected:

- The skill name is already referenced by users and documentation
- Splitting adds maintenance burden (two files to keep in sync)
- The callout + description change achieves the same routing effect: workers see the description and skip; orchestrators read the full file

The project-level override pattern (`.pi/messenger/crew/skills/`) remains available for projects that want an even slimmer worker-facing reference.

---

# Testing

Verified locally by:
1. Creating `.pi/messenger/crew/skills/pi-messenger-crew.md` as a project-level override (slim worker version)
2. Creating `.pi/messenger/crew/agents/crew-worker.md` as a local override with the skip list
3. Observing that a worker spawned in the next crew run no longer attempts to read the full skill

No functional behaviour changes — all existing crew operations work identically.
