### PR TITLE
Fix Windows crew prompts with temp files

### DIFF
--- a/crew/agents.ts
+++ b/crew/agents.ts
@@ -236,16 +236,6 @@ async function runAgent(
     // Pass extension so workers can use pi_messenger
     args.push("--extension", EXTENSION_DIR);
 
-    let promptTmpDir: string | null = null;
-    if (agentConfig?.systemPrompt) {
-      promptTmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-messenger-agent-"));
-      const promptPath = path.join(promptTmpDir, `${task.agent.replace(/[^\w.-]/g, "_")}.md`);
-      fs.writeFileSync(promptPath, agentConfig.systemPrompt, { mode: 0o600 });
-      args.push("--append-system-prompt", promptPath);
-    }
-
-    args.push(task.task);
-
     const envOverrides = config.work.env ?? {};
     const workerFlag = role === "worker"
       ? { PI_CREW_WORKER: "1", PI_AGENT_NAME: workerName }
@@ -253,6 +243,27 @@ async function runAgent(
     const env = Object.keys(envOverrides).length > 0 || role === "worker"
       ? { ...process.env, ...envOverrides, ...workerFlag }
       : undefined;
+
+    let promptTmpDir: string | null = null;
+    let promptPath: string | null = null;
+    try {
+      promptTmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-messenger-agent-"));
+      if (agentConfig?.systemPrompt) {
+        const systemPromptPath = path.join(promptTmpDir, `${task.agent.replace(/[^\w.-]/g, "_")}.system.md`);
+        fs.writeFileSync(systemPromptPath, agentConfig.systemPrompt, { mode: 0o600 });
+        args.push("--append-system-prompt", systemPromptPath);
+      }
+      promptPath = path.join(promptTmpDir, `${task.agent.replace(/[^\w.-]/g, "_")}.prompt.md`);
+      fs.writeFileSync(promptPath, task.task, { mode: 0o600 });
+      args.push(`@${promptPath}`);
+    } catch {
+      if (promptTmpDir) {
+        try { fs.rmSync(promptTmpDir, { recursive: true, force: true }); } catch {}
+      }
+      promptTmpDir = null;
+      promptPath = null;
+      args.push(task.task);
+    }
 
     const proc = spawnPi(args, {
       cwd,

--- a/crew/agents.ts
+++ b/crew/agents.ts
@@ -4,7 +4,6 @@
  * Spawns pi processes with progress tracking, truncation, and artifacts.
  */
 
-import { spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import * as fs from "node:fs";
 import * as os from "node:os";
@@ -31,6 +30,7 @@ import { removeLiveWorker, updateLiveWorker } from "./live-progress.js";
 import { autonomousState, waitForConcurrencyChange } from "./state.js";
 import { registerWorker, unregisterWorker, killAll } from "./registry.js";
 import type { AgentTask, AgentResult } from "./types.js";
+import { spawnPi } from "./utils/spawn-pi.js";
 import { generateMemorableName } from "../lib.js";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -254,7 +254,7 @@ async function runAgent(
       ? { ...process.env, ...envOverrides, ...workerFlag }
       : undefined;
 
-    const proc = spawn("pi", args, {
+    const proc = spawnPi(args, {
       cwd,
       stdio: ["ignore", "pipe", "pipe"],
       ...(env ? { env } : {}),

--- a/crew/lobby.ts
+++ b/crew/lobby.ts
@@ -96,18 +96,23 @@ export function spawnLobbyWorker(cwd: string, promptOverride?: string): LobbyWor
 
   args.push("--extension", EXTENSION_DIR);
 
-  let promptTmpDir: string | null = null;
-  if (workerConfig.systemPrompt) {
-    promptTmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-messenger-lobby-"));
-    const promptPath = path.join(promptTmpDir, "crew-worker.md");
-    fs.writeFileSync(promptPath, workerConfig.systemPrompt, { mode: 0o600 });
-    args.push("--append-system-prompt", promptPath);
-  }
-
-  args.push(prompt);
-
   const envOverrides = config.work.env ?? {};
   const env = { ...process.env, ...envOverrides, PI_AGENT_NAME: name, PI_CREW_WORKER: "1", PI_LOBBY_ID: id };
+
+  let promptTmpDir: string | null = null;
+  try {
+    promptTmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-messenger-lobby-"));
+    if (workerConfig.systemPrompt) {
+      const systemPromptPath = path.join(promptTmpDir, "crew-worker.system.md");
+      fs.writeFileSync(systemPromptPath, workerConfig.systemPrompt, { mode: 0o600 });
+      args.push("--append-system-prompt", systemPromptPath);
+    }
+    const promptPath = path.join(promptTmpDir, "crew-worker.prompt.md");
+    fs.writeFileSync(promptPath, prompt, { mode: 0o600 });
+    args.push(`@${promptPath}`);
+  } catch {
+    args.push(prompt);
+  }
 
   const proc = spawnPi(args, {
     cwd,

--- a/crew/lobby.ts
+++ b/crew/lobby.ts
@@ -6,7 +6,6 @@
  * receive assignments via steer message and transition to work mode.
  */
 
-import { spawn } from "node:child_process";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -14,6 +13,7 @@ import { fileURLToPath } from "node:url";
 import { randomUUID } from "node:crypto";
 import { generateMemorableName } from "../lib.js";
 import { resolveThinking, modelHasThinkingSuffix, pushModelArgs } from "./agents.js";
+import { spawnPi } from "./utils/spawn-pi.js";
 import { discoverCrewAgents } from "./utils/discover.js";
 import { loadCrewConfig, type CrewConfig } from "./utils/config.js";
 import {
@@ -109,7 +109,7 @@ export function spawnLobbyWorker(cwd: string, promptOverride?: string): LobbyWor
   const envOverrides = config.work.env ?? {};
   const env = { ...process.env, ...envOverrides, PI_AGENT_NAME: name, PI_CREW_WORKER: "1", PI_LOBBY_ID: id };
 
-  const proc = spawn("pi", args, {
+  const proc = spawnPi(args, {
     cwd,
     stdio: ["ignore", "pipe", "pipe"],
     env,

--- a/crew/utils/spawn-pi.ts
+++ b/crew/utils/spawn-pi.ts
@@ -1,0 +1,25 @@
+import { spawn, type ChildProcess, type SpawnOptions } from "node:child_process";
+
+export interface PiProcessSpec {
+  command: string;
+  args: string[];
+}
+
+export function buildPiProcessSpec(args: string[]): PiProcessSpec {
+  if (process.platform === "win32") {
+    return {
+      command: process.env.ComSpec || "cmd.exe",
+      args: ["/d", "/s", "/c", "pi", ...args],
+    };
+  }
+
+  return {
+    command: "pi",
+    args,
+  };
+}
+
+export function spawnPi(args: string[], options: SpawnOptions): ChildProcess {
+  const spec = buildPiProcessSpec(args);
+  return spawn(spec.command, spec.args, options);
+}

--- a/tests/crew/lobby.test.ts
+++ b/tests/crew/lobby.test.ts
@@ -244,12 +244,24 @@ describe("lobby workers", () => {
     const calls = vi.mocked(spawn).mock.calls;
     expect(calls.length).toBe(1);
     const promptArg = calls[0][1]![calls[0][1]!.length - 1] as string;
-    expect(promptArg).toContain("Crew Lobby");
-    expect(promptArg).toContain("docs/PRD.md");
-    expect(promptArg).toContain("Share Your Findings");
-    expect(promptArg).toContain("Introduce yourself");
-    expect(promptArg).toContain("at most 5 messages");
-    expect(promptArg).toContain("TASK ASSIGNMENT");
+    expect(promptArg.startsWith("@")).toBe(true);
+    const promptText = fs.readFileSync(promptArg.slice(1), "utf-8");
+    expect(promptText).toContain("Crew Lobby");
+    expect(promptText).toContain("docs/PRD.md");
+    expect(promptText).toContain("Share Your Findings");
+    expect(promptText).toContain("Introduce yourself");
+    expect(promptText).toContain("at most 5 messages");
+    expect(promptText).toContain("TASK ASSIGNMENT");
+  });
+
+  it("passes the lobby prompt through an @file reference", async () => {
+    const { spawn } = await import("node:child_process");
+    lobby.spawnLobbyWorker("/test/cwd");
+
+    const calls = vi.mocked(spawn).mock.calls;
+    const promptArg = calls[0][1]![calls[0][1]!.length - 1] as string;
+    expect(promptArg.startsWith("@")).toBe(true);
+    expect(calls[0][1]!.join(" ")).not.toContain("Crew Lobby");
   });
 
   it("close handler resets orphaned in_progress task to todo", async () => {
@@ -416,7 +428,9 @@ describe("lobby workers", () => {
 
     const calls = vi.mocked(spawn).mock.calls;
     const promptArg = calls[0][1]![calls[0][1]!.length - 1] as string;
-    expect(promptArg).toContain("Standing by for task assignment");
-    expect(promptArg).not.toContain("Chat With Your Team");
+    expect(promptArg.startsWith("@")).toBe(true);
+    const promptText = fs.readFileSync(promptArg.slice(1), "utf-8");
+    expect(promptText).toContain("Standing by for task assignment");
+    expect(promptText).not.toContain("Chat With Your Team");
   });
 });

--- a/tests/crew/model-override.test.ts
+++ b/tests/crew/model-override.test.ts
@@ -132,6 +132,22 @@ describe("crew/model override", () => {
     expect(args[modelIdx + 1]).toBe("glm-5");
   });
 
+  it("spawnAgents passes the task prompt through an @file reference", async () => {
+    writeWorkerAgent(dirs.cwd, "agent-default-model");
+
+    await spawnAgents([{
+      agent: "crew-worker",
+      task: "Implement task\nwith multiple lines\nand a longer body",
+      taskId: "task-1",
+    }], dirs.cwd);
+
+    const args = spawnMock.mock.calls[0][1] as string[];
+    const promptArg = args[args.length - 1];
+
+    expect(promptArg.startsWith("@")).toBe(true);
+    expect(args.join(" ")).not.toContain("Implement task");
+  });
+
   describe("pushModelArgs", () => {
     it("splits provider/model into separate flags", () => {
       const args: string[] = [];

--- a/tests/crew/spawn-pi.test.ts
+++ b/tests/crew/spawn-pi.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("crew/spawn-pi", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it("uses the pi binary directly on non-Windows platforms", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+
+    const { buildPiProcessSpec } = await import("../../crew/utils/spawn-pi.js");
+    expect(buildPiProcessSpec(["--version"])).toEqual({
+      command: "pi",
+      args: ["--version"],
+    });
+  });
+
+  it("uses cmd.exe shell resolution on Windows", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    vi.stubEnv("ComSpec", "C:\\Windows\\System32\\cmd.exe");
+
+    const { buildPiProcessSpec } = await import("../../crew/utils/spawn-pi.js");
+    expect(buildPiProcessSpec(["--version"])).toEqual({
+      command: "C:\\Windows\\System32\\cmd.exe",
+      args: ["/d", "/s", "/c", "pi", "--version"],
+    });
+  });
+
+  it("falls back to cmd.exe when ComSpec is missing on Windows", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    vi.stubEnv("ComSpec", "");
+
+    const { buildPiProcessSpec } = await import("../../crew/utils/spawn-pi.js");
+    expect(buildPiProcessSpec(["--mode", "json"])).toEqual({
+      command: "cmd.exe",
+      args: ["/d", "/s", "/c", "pi", "--mode", "json"],
+    });
+  });
+});


### PR DESCRIPTION
This changes the crew worker spawning flow to avoid Windows command-line length limits by writing prompts to temporary files and passing them to `pi` via `@file`.

Validated on Windows 11 with:
- `npx vitest run tests/crew/model-override.test.ts tests/crew/lobby.test.ts tests/crew/spawn-pi.test.ts`

Please also validate on macOS/Linux, since I only have Windows 11 available and cannot verify cross-platform behavior locally.
