### PR TITLE
fix(crew): enforce config.concurrency.max in spawnWorkersForReadyTasks

### DIFF
--- a/crew/spawn.ts
+++ b/crew/spawn.ts
@@ -31,6 +31,10 @@ export function spawnWorkersForReadyTasks(
 
   const crewDir = store.getCrewDir(cwd);
   const config = loadCrewConfig(crewDir);
+  const configMax = config.concurrency.max;
+  const cap = Number.isFinite(configMax) && configMax > 0
+    ? Math.min(maxWorkers, configMax)
+    : maxWorkers;
   const prdLabel = store.getPlanLabel(plan);
   const inboxDir = join(cwd, ".pi", "messenger", "inbox");
   const skills = discoverCrewSkills(cwd);
@@ -40,7 +44,7 @@ export function spawnWorkersForReadyTasks(
 
   const lobby = getAvailableLobbyWorkers(cwd);
   for (const lw of lobby) {
-    if (assigned >= maxWorkers) break;
+    if (assigned >= cap) break;
     const fresh = store.getReadyTasks(cwd, { advisory: config.dependencies === "advisory" });
     if (fresh.length === 0) break;
 
@@ -67,7 +71,7 @@ export function spawnWorkersForReadyTasks(
     assigned++;
   }
 
-  while (assigned < maxWorkers) {
+  while (assigned < cap) {
     const fresh = store.getReadyTasks(cwd, { advisory: config.dependencies === "advisory" });
     if (fresh.length === 0) break;
 

--- a/tests/crew/spawn.test.ts
+++ b/tests/crew/spawn.test.ts
@@ -1,0 +1,104 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createTempCrewDirs, type TempCrewDirs } from "../helpers/temp-dirs.js";
+
+const homedirMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:os")>();
+  return { ...actual, homedir: homedirMock };
+});
+
+const lobbyMock = vi.hoisted(() => {
+  let counter = 0;
+  return {
+    getAvailableLobbyWorkers: vi.fn(() => [] as Array<{ name: string; lobbyId: string }>),
+    assignTaskToLobbyWorker: vi.fn(() => true),
+    spawnWorkerForTask: vi.fn(() => {
+      counter++;
+      return { name: `SpawnedWorker${counter}`, lobbyId: `lobby-${counter}` };
+    }),
+    _reset: () => { counter = 0; },
+  };
+});
+
+vi.mock("../../crew/lobby.js", () => ({
+  getAvailableLobbyWorkers: lobbyMock.getAvailableLobbyWorkers,
+  assignTaskToLobbyWorker: lobbyMock.assignTaskToLobbyWorker,
+  spawnWorkerForTask: lobbyMock.spawnWorkerForTask,
+}));
+
+vi.mock("../../crew/utils/discover.js", () => ({
+  discoverCrewSkills: vi.fn(() => []),
+}));
+
+vi.mock("../../feed.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../feed.js")>();
+  return { ...actual, logFeedEvent: vi.fn() };
+});
+
+function writeProjectConfig(crewDir: string, config: Record<string, unknown>): void {
+  fs.mkdirSync(crewDir, { recursive: true });
+  fs.writeFileSync(path.join(crewDir, "config.json"), JSON.stringify(config, null, 2));
+}
+
+describe("spawnWorkersForReadyTasks concurrency cap", () => {
+  let dirs: TempCrewDirs;
+  let spawn: typeof import("../../crew/spawn.js");
+  let store: typeof import("../../crew/store.js");
+
+  beforeEach(async () => {
+    dirs = createTempCrewDirs();
+    homedirMock.mockReturnValue(dirs.root);
+    lobbyMock._reset();
+    lobbyMock.getAvailableLobbyWorkers.mockReturnValue([]);
+
+    vi.resetModules();
+    store = await import("../../crew/store.js");
+    spawn = await import("../../crew/spawn.js");
+
+    store.createPlan(dirs.cwd, "docs/PRD.md", "Test Plan");
+    for (let i = 0; i < 5; i++) {
+      store.createTask(dirs.cwd, `Task ${i + 1}`);
+    }
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("respects config.concurrency.max when caller requests more workers", () => {
+    writeProjectConfig(dirs.crewDir, { concurrency: { workers: 1, max: 1 } });
+
+    const result = spawn.spawnWorkersForReadyTasks(dirs.cwd, 5);
+
+    expect(result.assigned).toBe(1);
+    expect(lobbyMock.spawnWorkerForTask).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the caller limit when it is lower than config.concurrency.max", () => {
+    writeProjectConfig(dirs.crewDir, { concurrency: { workers: 2, max: 10 } });
+
+    const result = spawn.spawnWorkersForReadyTasks(dirs.cwd, 2);
+
+    expect(result.assigned).toBe(2);
+    expect(lobbyMock.spawnWorkerForTask).toHaveBeenCalledTimes(2);
+  });
+
+  it("caps lobby assignments by config.concurrency.max", () => {
+    writeProjectConfig(dirs.crewDir, { concurrency: { workers: 1, max: 1 } });
+
+    lobbyMock.getAvailableLobbyWorkers.mockReturnValue([
+      { name: "Lobby1", lobbyId: "lb-1" } as any,
+      { name: "Lobby2", lobbyId: "lb-2" } as any,
+      { name: "Lobby3", lobbyId: "lb-3" } as any,
+    ]);
+
+    const result = spawn.spawnWorkersForReadyTasks(dirs.cwd, 5);
+
+    expect(result.assigned).toBe(1);
+    expect(lobbyMock.assignTaskToLobbyWorker).toHaveBeenCalledTimes(1);
+    expect(lobbyMock.spawnWorkerForTask).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
`spawnWorkersForReadyTasks` in `crew/spawn.ts` loads `CrewConfig` but never consults `config.concurrency.max`. It uses the caller-supplied `maxWorkers` directly. Only the `handlers/work.ts` path applies `clampConcurrency()` against the config ceiling.

This leaks into the overlay auto-spawn paths:
  - `overlay.ts:142` (`checkAutoSpawnOnPlanComplete`)
  - `overlay.ts:168` (`checkAutoRefillWorkers`)

Both compute `target = Math.min(readyTasks.length, autonomousState.concurrency)`and pass it straight into `spawnWorkersForReadyTasks`. Since `autonomousState.concurrency` defaults to `2` (`crew/state-autonomous.ts:39`) and is only clamped on the `work()` path, the overlay will happily spawn 2 workers even when the project's `config.concurrency.max` is `1`.

### Observed impact
With `~/.pi/agent/pi-messenger.json` containing `crew.concurrency.max: 1`, two workers spawned back-to-back (213 ms apart, same cwd, same wave) against a resource-constrained llama-server backend, thrashing context and eventually OOMing.

The overlay auto-opens on planning (`autoOverlayPlanning: true` default), which is enough to trigger the bypass, users can hit this without ever manually opening the overlay.

## Fix
Compute an effective cap inside `spawnWorkersForReadyTasks` as `Math.min(maxWorkers, config.concurrency.max)` and use it for both the lobby-assign loop and the spawn loop. Mirrors the clamp already applied on the `work()` path, so the setting is honored regardless of entry point.

## Test plan
- [x] New `tests/crew/spawn.test.ts` covers:
  - caller request (5) > `config.concurrency.max` (1) -> only 1 spawned
  - caller request (2) < `config.concurrency.max` (10) -> 2 spawned (no regression)
  - lobby-worker path also respects the cap
- [x] All 341 existing tests still pass
- [x] Reverting the fix makes the new tests fail (bug reproduction verified)