### PR TITLE
fix: guard updateStatus against stale ExtensionContext after session reload

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -228,64 +228,75 @@ export default function piMessengerExtension(pi: ExtensionAPI) {
   // ===========================================================================
 
   function updateStatus(ctx: ExtensionContext): void {
-    if (!ctx.hasUI || !state.registered) return;
+    try {
+      if (!ctx.hasUI || !state.registered) return;
 
-    checkStuckAgents(ctx);
+      checkStuckAgents(ctx);
 
-    const agents = store.getActiveAgents(state, dirs);
-    const activeNames = new Set(agents.map(a => a.name));
-    const count = agents.length;
-    const theme = ctx.ui.theme;
+      const agents = store.getActiveAgents(state, dirs);
+      const activeNames = new Set(agents.map(a => a.name));
+      const count = agents.length;
+      const theme = ctx.ui.theme;
 
-    for (const name of state.unreadCounts.keys()) {
-      if (!activeNames.has(name)) {
-        state.unreadCounts.delete(name);
-      }
-    }
-    for (const name of notifiedStuck) {
-      if (!activeNames.has(name)) {
-        notifiedStuck.delete(name);
-      }
-    }
-
-    // Sum remaining unread counts
-    let totalUnread = 0;
-    for (const n of state.unreadCounts.values()) totalUnread += n;
-
-    const nameStr = theme.fg("accent", state.agentName);
-    const countStr = theme.fg("dim", ` (${count} peer${count === 1 ? "" : "s"})`);
-    const unreadStr = totalUnread > 0 ? theme.fg("accent", ` ●${totalUnread}`) : "";
-
-    const planningCwd = ctx.cwd ?? process.cwd();
-    const planningStr =
-      isPlanningForCwd(planningCwd)
-        ? theme.fg(
-            "warning",
-            ` · plan ${planningState.pass}/${planningState.maxPasses} ${planningState.phase}${isPlanningStalled(planningCwd) ? " stalled" : ""}`,
-          )
-        : "";
-
-    const activityStr = !planningStr && state.activity.currentActivity
-      ? theme.fg("dim", ` · ${state.activity.currentActivity}`)
-      : "";
-
-    // Add crew status if autonomous mode is active
-    let crewStr = "";
-    if (autonomousState.active) {
-      const cwd = ctx.cwd ?? process.cwd();
-      const plan = crewStore.getPlan(cwd);
-      if (plan) {
-        const workerCount = getLiveWorkers(cwd).size;
-        crewStr = theme.fg("accent", ` ⚡${plan.completed_count}/${plan.task_count}`);
-        if (workerCount > 0) {
-          crewStr += theme.fg("dim", ` 🔨${workerCount}`);
+      for (const name of state.unreadCounts.keys()) {
+        if (!activeNames.has(name)) {
+          state.unreadCounts.delete(name);
         }
       }
+      for (const name of notifiedStuck) {
+        if (!activeNames.has(name)) {
+          notifiedStuck.delete(name);
+        }
+      }
+
+      // Sum remaining unread counts
+      let totalUnread = 0;
+      for (const n of state.unreadCounts.values()) totalUnread += n;
+
+      const nameStr = theme.fg("accent", state.agentName);
+      const countStr = theme.fg("dim", ` (${count} peer${count === 1 ? "" : "s"})`);
+      const unreadStr = totalUnread > 0 ? theme.fg("accent", ` ●${totalUnread}`) : "";
+
+      const planningCwd = ctx.cwd ?? process.cwd();
+      const planningStr =
+        isPlanningForCwd(planningCwd)
+          ? theme.fg(
+              "warning",
+              ` · plan ${planningState.pass}/${planningState.maxPasses} ${planningState.phase}${isPlanningStalled(planningCwd) ? " stalled" : ""}`,
+            )
+          : "";
+
+      const activityStr = !planningStr && state.activity.currentActivity
+        ? theme.fg("dim", ` · ${state.activity.currentActivity}`)
+        : "";
+
+      // Add crew status if autonomous mode is active
+      let crewStr = "";
+      if (autonomousState.active) {
+        const cwd = ctx.cwd ?? process.cwd();
+        const plan = crewStore.getPlan(cwd);
+        if (plan) {
+          const workerCount = getLiveWorkers(cwd).size;
+          crewStr = theme.fg("accent", ` ⚡${plan.completed_count}/${plan.task_count}`);
+          if (workerCount > 0) {
+            crewStr += theme.fg("dim", ` 🔨${workerCount}`);
+          }
+        }
+      }
+
+      ctx.ui.setStatus("messenger", `msg: ${nameStr}${countStr}${unreadStr}${planningStr}${activityStr}${crewStr}`);
+
+      maybeAutoOpenCrewOverlay(ctx);
+    } catch {
+      // Guard against stale ExtensionContext after session replacement or reload.
+      // The status heartbeat timer and onLiveWorkersChanged listener capture
+      // latestCtx, which becomes stale when pi calls ctx.newSession(), ctx.fork(),
+      // ctx.switchSession(), or ctx.reload(). Accessing properties like ctx.hasUI
+      // on a stale ctx throws. Clean up and stop the heartbeat to prevent repeated
+      // crashes until a fresh ctx is provided.
+      latestCtx = null;
+      stopStatusHeartbeat();
     }
-
-    ctx.ui.setStatus("messenger", `msg: ${nameStr}${countStr}${unreadStr}${planningStr}${activityStr}${crewStr}`);
-
-    maybeAutoOpenCrewOverlay(ctx);
   }
 
   function clearAllUnreadCounts(): void {


### PR DESCRIPTION
## Problem

`pi-messenger` crashes with an unhandled error when pi replaces or reloads a session:

```
Error: This extension ctx is stale after session replacement or reload.
  Do not use a captured pi or command ctx after ctx.newSession(), ctx.fork(),
  ctx.switchSession(), or ctx.reload().
    at ExtensionRunner.assertActive (runner.js:297)
    at get hasUI (runner.js:386)
    at updateStatus (pi-messenger/index.ts:231)
    at Timeout._onTimeout (pi-messenger/index.ts:322)
```

### Root Cause

`updateStatus()` is called from two deferred/async sources:

1. **Status heartbeat timer** — a `setInterval` firing every 15 seconds (line 322)
2. **`onLiveWorkersChanged` listener** — an event callback (line 333)

Both use a captured `latestCtx` reference. When pi replaces or reloads a session (via `ctx.newSession()`, `ctx.fork()`, `ctx.switchSession()`, or `ctx.reload()`), the old `ExtensionContext` is invalidated. Any property access on it (e.g. `ctx.hasUI`) calls `assertActive()` which throws.

Since the timer and listener keep firing with the stale reference, this crashes pi on the next heartbeat tick after any session change.

## Fix

Wrap the entire `updateStatus()` body in a `try/catch`. When a stale ctx error is caught:

1. Null out `latestCtx` to prevent further stale access attempts
2. Stop the heartbeat timer to avoid repeated crashes

The next call site that provides a fresh `ctx` (e.g. a new command invocation) will restore `latestCtx` and restart the heartbeat normally.

## Testing

Reproduced by triggering a session reload while pi-messenger is running with an active heartbeat. After the fix, the error is silently caught and the heartbeat cleanly stops instead of crashing.